### PR TITLE
cleanup and c++ standard fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VPATH  := src src/Lzh src/Zip src/common
 CXX	= c++
 COMMONFLAGS = -Os -Wall -Wsign-compare -Wnarrowing -Wno-error=multichar -Wno-multichar -Isrc
 CFLAGS	= $(COMMONFLAGS)
-CXXFLAGS = $(COMMONFLAGS) -std=c++14 -fno-rtti
+CXXFLAGS = $(COMMONFLAGS) -std=c++17 -fno-rtti
 
 PROG	= ancient
 OBJS	= Buffer.o Common.o MemoryBuffer.o StaticBuffer.o SubBuffer.o CRC16.o CRC32.o \

--- a/extra/BruteForceRNC1Encoder.cpp
+++ b/extra/BruteForceRNC1Encoder.cpp
@@ -4,8 +4,8 @@
 
 #include <memory>
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include <fstream>
 #include <vector>
@@ -13,7 +13,7 @@
 #include <algorithm>
 #include <functional>
 
-#include <stdio.h>
+#include <cstdio>
 #include <dirent.h>
 #include <sys/stat.h>
 
@@ -500,7 +500,7 @@ void packRNC(Buffer &dest,const Buffer &source,uint32_t chunkSize)
 	stream[17]=chunkCount;
 
 	dest.resize(stream.size());
-	::memcpy(dest.data(),stream.data(),stream.size());
+	std::memcpy(dest.data(),stream.data(),stream.size());
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <memory>
 #include <fstream>
@@ -8,7 +8,7 @@
 #include <string>
 #include <functional>
 
-#include <stdio.h>
+#include <cstdio>
 #include <dirent.h>
 #include <sys/stat.h>
 

--- a/src/BZIP2Decompressor.cpp
+++ b/src/BZIP2Decompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "BZIP2Decompressor.hpp"
 #include "HuffmanDecoder.hpp"

--- a/src/CYB2Decoder.cpp
+++ b/src/CYB2Decoder.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <string.h>
+#include <cstring>
 
 #include "common/SubBuffer.hpp"
 #include "CYB2Decoder.hpp"

--- a/src/DEFLATEDecompressor.cpp
+++ b/src/DEFLATEDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "DEFLATEDecompressor.hpp"
 #include "HuffmanDecoder.hpp"

--- a/src/DMSDecompressor.cpp
+++ b/src/DMSDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "DMSDecompressor.hpp"
 
@@ -244,7 +244,7 @@ void DMSDecompressor::decompressImpl(Buffer &rawData,bool verify,uint32_t &resta
 	};
 
 	// fill unused tracks with zeros
-	::memset(rawData.data(),0,_rawSize);
+	std::memset(rawData.data(),0,_rawSize);
 
 	auto checksum=[](const uint8_t *src,uint32_t srcLength)->uint16_t
 	{
@@ -328,7 +328,7 @@ void DMSDecompressor::decompressImpl(Buffer &rawData,bool verify,uint32_t &resta
 	{
 		if (doInitContext)
 		{
-			if (_contextBufferSize) ::memset(contextBuffer.data(),0,_contextBufferSize);
+			if (_contextBufferSize) std::memset(contextBuffer.data(),0,_contextBufferSize);
 			quickContextLocation=251;
 			mediumContextLocation=16318;
 			deepContextLocation=16324;

--- a/src/Decompressor.hpp
+++ b/src/Decompressor.hpp
@@ -3,8 +3,8 @@
 #ifndef DECOMPRESSOR_HPP
 #define DECOMPRESSOR_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include <string>
 #include <memory>

--- a/src/DynamicHuffmanDecoder.hpp
+++ b/src/DynamicHuffmanDecoder.hpp
@@ -3,8 +3,8 @@
 #ifndef DYNAMICHUFFMANDECODER_HPP
 #define DYNAMICHUFFMANDECODER_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 // For exception
 #include "Decompressor.hpp"

--- a/src/HuffmanDecoder.hpp
+++ b/src/HuffmanDecoder.hpp
@@ -3,8 +3,8 @@
 #ifndef HUFFMANDECODER_HPP
 #define HUFFMANDECODER_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include <vector>
 #include <utility>

--- a/src/InputStream.hpp
+++ b/src/InputStream.hpp
@@ -3,8 +3,8 @@
 #ifndef INPUTSTREAM_HPP
 #define INPUTSTREAM_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include <algorithm>
 

--- a/src/LIN1Decompressor.cpp
+++ b/src/LIN1Decompressor.cpp
@@ -80,7 +80,7 @@ void LIN1Decompressor::decompressImpl(Buffer &rawData,const Buffer &previousData
 					} else count+=7;
 				} else count+=4;
 			}
-			uint32_t distance;
+			uint32_t distance = 0;
 			switch (readBits(2))
 			{
 				case 0:

--- a/src/LZCBDecompressor.cpp
+++ b/src/LZCBDecompressor.cpp
@@ -31,7 +31,7 @@ public:
 		for (uint32_t i=_levels-2;;i--)
 		{
 			uint16_t tmp=_tree[_levelOffsets[i]+symbol];
-			if (symbol+1<_levelSizes[i] && value>=tmp)
+			if (uint32_t(symbol+1)<_levelSizes[i] && value>=tmp)
 			{
 				symbol++;
 				low+=tmp;

--- a/src/LZXDecompressor.cpp
+++ b/src/LZXDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "LZXDecompressor.hpp"
 #include "HuffmanDecoder.hpp"
@@ -75,7 +75,7 @@ void LZXDecompressor::decompressImpl(Buffer &rawData,const Buffer &previousData,
 	if (!_isCompressed)
 	{
 		if (_packedSize!=_rawSize) throw Decompressor::DecompressionError();
-		::memcpy(rawData.data(),_packedData.data()+_packedOffset,_rawSize);
+		std::memcpy(rawData.data(),_packedData.data()+_packedOffset,_rawSize);
 		return;
 	}
 

--- a/src/Lzh/LZHDecompressor.cpp
+++ b/src/Lzh/LZHDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include <map>
 
@@ -94,7 +94,7 @@ void LZHDecompressor::decompressImpl(Buffer &rawData,bool verify)
 		case Compressor::LZ4:
 		case Compressor::PM0:
 		if (rawData.size()!=_packedData.size()) throw DecompressionError();
-		::memcpy(rawData.data(),_packedData.data(),rawData.size());
+		std::memcpy(rawData.data(),_packedData.data(),rawData.size());
 		break;
 
 		case Compressor::LH1:

--- a/src/MMCMPDecompressor.cpp
+++ b/src/MMCMPDecompressor.cpp
@@ -1,5 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
+#include <cstring>
+
 #include "MMCMPDecompressor.hpp"
 #include "InputStream.hpp"
 #include "OutputStream.hpp"
@@ -64,7 +66,7 @@ void MMCMPDecompressor::decompressImpl(Buffer &rawData,bool verify)
 {
 	if (rawData.size()<_rawSize) throw DecompressionError();
 	// MMCMP allows gaps in data. Although not used in practice still we memset before decompressing to be sure
-	::memset(rawData.data(),0,rawData.size());
+	std::memset(rawData.data(),0,rawData.size());
 
 	uint8_t *rawDataPtr=rawData.data();
 	for (uint32_t i=0;i<_blocks;i++)

--- a/src/NONEDecompressor.cpp
+++ b/src/NONEDecompressor.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <string.h>
+#include <cstring>
 
 #include "NONEDecompressor.hpp"
 
@@ -36,7 +36,7 @@ void NONEDecompressor::decompressImpl(Buffer &rawData,const Buffer &previousData
 {
 	if (rawData.size()!=_packedData.size()) throw Decompressor::DecompressionError();
 
-	::memcpy(rawData.data(),_packedData.data(),_packedData.size());
+	std::memcpy(rawData.data(),_packedData.data(),_packedData.size());
 }
 
 XPKDecompressor::Registry<NONEDecompressor> NONEDecompressor::_XPKregistration;

--- a/src/NUKEDecompressor.cpp
+++ b/src/NUKEDecompressor.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <string.h>
+#include <cstring>
 
 #include "NUKEDecompressor.hpp"
 #include "DLTADecode.hpp"

--- a/src/OutputStream.cpp
+++ b/src/OutputStream.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <string.h>
+#include <cstring>
 
 #include <algorithm>
 
@@ -82,7 +82,7 @@ const uint8_t *ForwardOutputStream::history(size_t distance) const
 void ForwardOutputStream::produce(const uint8_t *src,size_t bytes)
 {
 	if (_currentOffset+bytes>_endOffset) throw Decompressor::DecompressionError();
-	::memcpy(&_bufPtr[_currentOffset],src,bytes);
+	std::memcpy(&_bufPtr[_currentOffset],src,bytes);
 	_currentOffset+=bytes;
 }
 

--- a/src/OutputStream.hpp
+++ b/src/OutputStream.hpp
@@ -3,8 +3,8 @@
 #ifndef OUTPUTSTREAM_HPP
 #define OUTPUTSTREAM_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include "common/Buffer.hpp"
 

--- a/src/RangeDecoder.hpp
+++ b/src/RangeDecoder.hpp
@@ -3,7 +3,7 @@
 #ifndef RANGEDECODER_HPP
 #define RANGEDECODER_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 // used by too many compressors...
 class RangeDecoder

--- a/src/SDHCDecompressor.cpp
+++ b/src/SDHCDecompressor.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <string.h>
+#include <cstring>
 
 #include "common/SubBuffer.hpp"
 #include "SDHCDecompressor.hpp"
@@ -51,7 +51,7 @@ void SDHCDecompressor::decompressImpl(Buffer &rawData,const Buffer &previousData
 		master.decompress(rawData,verify);
 	} else {
 		if (src.size()!=rawData.size()) throw Decompressor::DecompressionError();
-		::memcpy(rawData.data(),src.data(),src.size());
+		std::memcpy(rawData.data(),src.data(),src.size());
 	}
 
 	size_t length=rawData.size()&~3U;

--- a/src/SXSCDecompressor.cpp
+++ b/src/SXSCDecompressor.cpp
@@ -195,7 +195,7 @@ void SXSCDecompressor::decompressASC(Buffer &rawData,ForwardInputStream &inputSt
 			outputStream.writeByte(twoStepArithDecoder(litInitial,litDynamic,litThreshold,1000,1,8));
 		} else {
 			// copy
-			while (outputStream.getOffset()>(1<<distanceIndex) && distanceIndex<15)
+			while (outputStream.getOffset()>size_t(1<<distanceIndex) && distanceIndex<15)
 				updateTable(distanceCodes,6000,++distanceIndex,24);
 			uint16_t distanceValue=arithDecoder.decode(tableSize(distanceCodes));
 			uint16_t distanceBits=decodeSymbol(distanceCodes,distanceValue);

--- a/src/SXSCDecompressor.hpp
+++ b/src/SXSCDecompressor.hpp
@@ -3,7 +3,7 @@
 #ifndef SXSCDECOMPRESSOR_HPP
 #define SXSCDECOMPRESSOR_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "XPKDecompressor.hpp"
 #include "InputStream.hpp"

--- a/src/XPKDecompressor.hpp
+++ b/src/XPKDecompressor.hpp
@@ -3,8 +3,8 @@
 #ifndef XPKDECOMPRESSOR_HPP
 #define XPKDECOMPRESSOR_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include <string>
 

--- a/src/XPKMaster.cpp
+++ b/src/XPKMaster.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <algorithm>
 
@@ -168,7 +168,7 @@ void XPKMaster::decompressImpl(Buffer &rawData,bool verify)
 		{
 			case 0:
 			if (rawChunkSize!=chunk.size()) throw Decompressor::DecompressionError();;
-			::memcpy(DestBuffer.data(),chunk.data(),rawChunkSize);
+			std::memcpy(DestBuffer.data(),chunk.data(),rawChunkSize);
 			break;
 
 			case 1:
@@ -199,7 +199,7 @@ void XPKMaster::decompressImpl(Buffer &rawData,bool verify)
 
 	if (verify)
 	{
-		if (::memcmp(_packedData.data()+16,rawData.data(),std::min(_rawSize,16U))) throw Decompressor::DecompressionError();
+		if (std::memcmp(_packedData.data()+16,rawData.data(),std::min(_rawSize,16U))) throw Decompressor::DecompressionError();
 	}
 }
 

--- a/src/Zip/ImplodeDecompressor.cpp
+++ b/src/Zip/ImplodeDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "ImplodeDecompressor.hpp"
 #include "../InputStream.hpp"

--- a/src/Zip/ReduceDecompressor.cpp
+++ b/src/Zip/ReduceDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "ReduceDecompressor.hpp"
 #include "../InputStream.hpp"

--- a/src/Zip/ShrinkDecompressor.cpp
+++ b/src/Zip/ShrinkDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "ShrinkDecompressor.hpp"
 #include "../InputStream.hpp"

--- a/src/Zip/ZIPDecompressor.cpp
+++ b/src/Zip/ZIPDecompressor.cpp
@@ -1,7 +1,7 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "ZIPDecompressor.hpp"
 
@@ -48,7 +48,7 @@ void ZIPDecompressor::decompressImpl(Buffer &rawData,bool verify)
 	{
 		case 0:
 		if (rawData.size()!=_packedData.size()) throw DecompressionError();
-		::memcpy(rawData.data(),_packedData.data(),rawData.size());
+		std::memcpy(rawData.data(),_packedData.data(),rawData.size());
 		break;
 
 		case 1:

--- a/src/common/Buffer.hpp
+++ b/src/common/Buffer.hpp
@@ -3,8 +3,8 @@
 #ifndef BUFFER_HPP
 #define BUFFER_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include <exception>
 

--- a/src/common/CRC16.cpp
+++ b/src/common/CRC16.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "Buffer.hpp"
 

--- a/src/common/CRC16.hpp
+++ b/src/common/CRC16.hpp
@@ -3,7 +3,7 @@
 #ifndef CRC16_HPP
 #define CRC16_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "Buffer.hpp"
 

--- a/src/common/CRC32.cpp
+++ b/src/common/CRC32.cpp
@@ -1,6 +1,6 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "Buffer.hpp"
 

--- a/src/common/CRC32.hpp
+++ b/src/common/CRC32.hpp
@@ -3,7 +3,7 @@
 #ifndef CRC32_HPP
 #define CRC32_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "Buffer.hpp"
 

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -3,7 +3,7 @@
 #ifndef COMMON_HPP
 #define COMMON_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <string>
 #include <vector>

--- a/src/common/MemoryBuffer.cpp
+++ b/src/common/MemoryBuffer.cpp
@@ -1,14 +1,14 @@
 /* Copyright (C) Teemu Suutari */
 
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 #include <memory>
 
 #include "MemoryBuffer.hpp"
 
 MemoryBuffer::MemoryBuffer(size_t size) :
-	_data(reinterpret_cast<uint8_t*>(::malloc(size))),
+	_data(reinterpret_cast<uint8_t*>(std::malloc(size))),
 	_size(size)
 {
 	if (!_data) throw OutOfMemoryError();
@@ -18,13 +18,13 @@ MemoryBuffer::MemoryBuffer(const Buffer &src,size_t offset,size_t size) :
 	MemoryBuffer(size)
 {
 	if(offset+size>src.size()) throw InvalidOperationError();
-	::memcpy(_data,src.data()+offset,size);
+	std::memcpy(_data,src.data()+offset,size);
 }
 
 
 MemoryBuffer::~MemoryBuffer()
 {
-	::free(_data);
+	std::free(_data);
 }
 
 const uint8_t *MemoryBuffer::data() const noexcept
@@ -49,7 +49,7 @@ bool MemoryBuffer::isResizable() const noexcept
 
 void MemoryBuffer::resize(size_t newSize) 
 {
-	_data=reinterpret_cast<uint8_t*>(::realloc(_data,newSize));
+	_data=reinterpret_cast<uint8_t*>(std::realloc(_data,newSize));
 	_size=newSize;
 	if (!_data)
 	{

--- a/src/common/StaticBuffer.hpp
+++ b/src/common/StaticBuffer.hpp
@@ -3,8 +3,8 @@
 #ifndef STATICBUFFER_HPP
 #define STATICBUFFER_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include "Buffer.hpp"
 

--- a/src/common/SubBuffer.hpp
+++ b/src/common/SubBuffer.hpp
@@ -3,8 +3,8 @@
 #ifndef SUBBUFFER_HPP
 #define SUBBUFFER_HPP
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include "Buffer.hpp"
 


### PR DESCRIPTION
- switch to c++17 to avoid compile error by default
- fix signed and uninitialized warnings
- fix missing cstring include
- switch  c xxx.h includes to cxxx and add std namespace