### PR TITLE
Modify FourCC to not rely on implementation-defined C++ features

### DIFF
--- a/src/ACCADecompressor.cpp
+++ b/src/ACCADecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool ACCADecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('ACCA');
+	return hdr==FourCC("ACCA");
 }
 
 std::unique_ptr<XPKDecompressor> ACCADecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/ARTMDecompressor.cpp
+++ b/src/ARTMDecompressor.cpp
@@ -7,7 +7,7 @@
 
 bool ARTMDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('ARTM');
+	return hdr==FourCC("ARTM");
 }
 
 std::unique_ptr<XPKDecompressor> ARTMDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/BLZWDecompressor.cpp
+++ b/src/BLZWDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool BLZWDecompressor::detectHeaderXPK(uint32_t hdr)
 {
-	return hdr==FourCC('BLZW');
+	return hdr==FourCC("BLZW");
 }
 
 std::unique_ptr<XPKDecompressor> BLZWDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/BZIP2Decompressor.cpp
+++ b/src/BZIP2Decompressor.cpp
@@ -12,12 +12,12 @@
 
 bool BZIP2Decompressor::detectHeader(uint32_t hdr) noexcept
 {
-	return ((hdr&0xffff'ff00U)==FourCC('BZh\0') && (hdr&0xffU)>='1' && (hdr&0xffU)<='9');
+	return ((hdr&0xffff'ff00U)==FourCC("BZh\0") && (hdr&0xffU)>='1' && (hdr&0xffU)<='9');
 }
 
 bool BZIP2Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return (hdr==FourCC('BZP2'));
+	return (hdr==FourCC("BZP2"));
 }
 
 std::unique_ptr<Decompressor> BZIP2Decompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)

--- a/src/CBR0Decompressor.cpp
+++ b/src/CBR0Decompressor.cpp
@@ -7,7 +7,7 @@
 bool CBR0Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
 	// CBR1 is practical joke: it is the same as CBR0 but with ID changed
-	return hdr==FourCC('CBR0') || hdr==FourCC('CBR1');
+	return hdr==FourCC("CBR0") || hdr==FourCC("CBR1");
 }
 
 std::unique_ptr<XPKDecompressor> CBR0Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -18,7 +18,7 @@ std::unique_ptr<XPKDecompressor> CBR0Decompressor::create(uint32_t hdr,uint32_t 
 CBR0Decompressor::CBR0Decompressor(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify) :
 	XPKDecompressor(recursionLevel),
 	_packedData(packedData),
-	_isCBR0(hdr==FourCC('CBR0'))
+	_isCBR0(hdr==FourCC("CBR0"))
 {
 	if (!detectHeaderXPK(hdr)) throw Decompressor::InvalidFormatError();
 }

--- a/src/CRMDecompressor.cpp
+++ b/src/CRMDecompressor.cpp
@@ -10,10 +10,10 @@ bool CRMDecompressor::detectHeader(uint32_t hdr) noexcept
 {
 	switch (hdr)
 	{
-		case FourCC('CrM!'):
-		case FourCC('CrM2'):
-		case FourCC('Crm!'):
-		case FourCC('Crm2'):
+		case FourCC("CrM!"):
+		case FourCC("CrM2"):
+		case FourCC("Crm!"):
+		case FourCC("Crm2"):
 		return true;
 
 		default:
@@ -23,7 +23,7 @@ bool CRMDecompressor::detectHeader(uint32_t hdr) noexcept
 
 bool CRMDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('CRM2') || hdr==FourCC('CRMS');
+	return hdr==FourCC("CRM2") || hdr==FourCC("CRMS");
 }
 
 std::unique_ptr<Decompressor> CRMDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)
@@ -56,7 +56,7 @@ CRMDecompressor::CRMDecompressor(const Buffer &packedData,uint32_t recursionLeve
 CRMDecompressor::CRMDecompressor(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify) :
 	CRMDecompressor(packedData,recursionLevel,verify)
 {
-	_isXPKDelta=(hdr==FourCC('CRMS'));
+	_isXPKDelta=(hdr==FourCC("CRMS"));
 }
 
 CRMDecompressor::~CRMDecompressor()

--- a/src/CYB2Decoder.cpp
+++ b/src/CYB2Decoder.cpp
@@ -8,7 +8,7 @@
 
 bool CYB2Decoder::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('CYB2');
+	return hdr==FourCC("CYB2");
 }
 
 std::unique_ptr<XPKDecompressor> CYB2Decoder::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/DEFLATEDecompressor.cpp
+++ b/src/DEFLATEDecompressor.cpp
@@ -32,7 +32,7 @@ bool DEFLATEDecompressor::detectHeader(uint32_t hdr) noexcept
 
 bool DEFLATEDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return (hdr==FourCC('GZIP'));
+	return (hdr==FourCC("GZIP"));
 }
 
 std::unique_ptr<Decompressor> DEFLATEDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)

--- a/src/DLTADecode.cpp
+++ b/src/DLTADecode.cpp
@@ -4,7 +4,7 @@
 
 bool DLTADecode::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('DLTA');
+	return hdr==FourCC("DLTA");
 }
 
 std::unique_ptr<XPKDecompressor> DLTADecode::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/DMSDecompressor.cpp
+++ b/src/DMSDecompressor.cpp
@@ -15,7 +15,7 @@
 
 bool DMSDecompressor::detectHeader(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('DMS!');
+	return hdr==FourCC("DMS!");
 }
 
 std::unique_ptr<Decompressor> DMSDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)
@@ -629,7 +629,7 @@ void DMSDecompressor::decompressImpl(Buffer &rawData,bool verify,uint32_t &resta
 					inputUnObsfuscator.setCode(restartPosition);
 					limitedDecompress=8;
 					processBlock(doRLE,func,params...);
-					if ((rawData.readBE32(0)&0xffff'ff00U)!=FourCC('DOS\0')) continue;
+					if ((rawData.readBE32(0)&0xffff'ff00U)!=FourCC("DOS\0")) continue;
 
 					// now see if the candidate is any good
 					doInitContext=true;

--- a/src/FASTDecompressor.cpp
+++ b/src/FASTDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool FASTDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('FAST');
+	return hdr==FourCC("FAST");
 }
 
 std::unique_ptr<XPKDecompressor> FASTDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/FBR2Decompressor.cpp
+++ b/src/FBR2Decompressor.cpp
@@ -6,7 +6,7 @@
 
 bool FBR2Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('FBR2');
+	return hdr==FourCC("FBR2");
 }
 
 std::unique_ptr<XPKDecompressor> FBR2Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/FRLEDecompressor.cpp
+++ b/src/FRLEDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool FRLEDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('FRLE');
+	return hdr==FourCC("FRLE");
 }
 
 std::unique_ptr<XPKDecompressor> FRLEDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/HFMNDecompressor.cpp
+++ b/src/HFMNDecompressor.cpp
@@ -7,7 +7,7 @@
 
 bool HFMNDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('HFMN');
+	return hdr==FourCC("HFMN");
 }
 
 std::unique_ptr<XPKDecompressor> HFMNDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/HUFFDecompressor.cpp
+++ b/src/HUFFDecompressor.cpp
@@ -7,7 +7,7 @@
 
 bool HUFFDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('HUFF');
+	return hdr==FourCC("HUFF");
 }
 
 std::unique_ptr<XPKDecompressor> HUFFDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/ILZRDecompressor.cpp
+++ b/src/ILZRDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool ILZRDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('ILZR');
+	return hdr==FourCC("ILZR");
 }
 
 std::unique_ptr<XPKDecompressor> ILZRDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/IMPDecompressor.cpp
+++ b/src/IMPDecompressor.cpp
@@ -9,27 +9,27 @@ static bool readIMPHeader(uint32_t hdr,uint32_t &addition) noexcept
 {
 	switch (hdr)
 	{
-		case FourCC('ATN!'):
-		case FourCC('EDAM'):
-		case FourCC('IMP!'):
-		case FourCC('M.H.'):
+		case FourCC("ATN!"):
+		case FourCC("EDAM"):
+		case FourCC("IMP!"):
+		case FourCC("M.H."):
 		addition=7;
 		return true;
 
-		case FourCC('BDPI'):
+		case FourCC("BDPI"):
 		addition=0x6e8;
 		return true;
 
-		case FourCC('CHFI'):
+		case FourCC("CHFI"):
 		addition=0xfe4;
 		return true;
 
-		case FourCC('RDC9'):	// Files do not contain checksum
+		case FourCC("RDC9"):	// Files do not contain checksum
 
 		// I haven't got these files to be sure what is the addition
-		case FourCC('Dupa'):
-		case FourCC('FLT!'):
-		case FourCC('PARA'):
+		case FourCC("Dupa"):
+		case FourCC("FLT!"):
+		case FourCC("PARA"):
 		addition=0; 		// disable checksum for now
 		return true;
 
@@ -46,7 +46,7 @@ bool IMPDecompressor::detectHeader(uint32_t hdr) noexcept
 
 bool IMPDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('IMPL');
+	return hdr==FourCC("IMPL");
 }
 
 std::unique_ptr<Decompressor> IMPDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)

--- a/src/LHLBDecompressor.cpp
+++ b/src/LHLBDecompressor.cpp
@@ -8,7 +8,7 @@
 
 bool LHLBDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LHLB');
+	return hdr==FourCC("LHLB");
 }
 
 std::unique_ptr<XPKDecompressor> LHLBDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/LIN1Decompressor.cpp
+++ b/src/LIN1Decompressor.cpp
@@ -7,7 +7,7 @@
 
 bool LIN1Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LIN1') || hdr==FourCC('LIN3');
+	return hdr==FourCC("LIN1") || hdr==FourCC("LIN3");
 }
 
 std::unique_ptr<XPKDecompressor> LIN1Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -20,7 +20,7 @@ LIN1Decompressor::LIN1Decompressor(uint32_t hdr,uint32_t recursionLevel,const Bu
 	_packedData(packedData)
 {
 	if (!detectHeaderXPK(hdr)) throw Decompressor::InvalidFormatError();
-	_ver=(hdr==FourCC('LIN1'))?1:3;
+	_ver=(hdr==FourCC("LIN1"))?1:3;
 	if (packedData.size()<5) throw Decompressor::InvalidFormatError();
 
 	uint32_t tmp=packedData.readBE32(0);

--- a/src/LIN2Decompressor.cpp
+++ b/src/LIN2Decompressor.cpp
@@ -7,7 +7,7 @@
 
 bool LIN2Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LIN2') || hdr==FourCC('LIN4');
+	return hdr==FourCC("LIN2") || hdr==FourCC("LIN4");
 }
 
 std::unique_ptr<XPKDecompressor> LIN2Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -20,7 +20,7 @@ LIN2Decompressor::LIN2Decompressor(uint32_t hdr,uint32_t recursionLevel,const Bu
 	_packedData(packedData)
 {
 	if (!detectHeaderXPK(hdr)) throw Decompressor::InvalidFormatError();
-	_ver=(hdr==FourCC('LIN2'))?2:4;
+	_ver=(hdr==FourCC("LIN2"))?2:4;
 	if (packedData.size()<10) throw Decompressor::InvalidFormatError();
 
 	uint32_t tmp=packedData.readBE32(0);

--- a/src/LZBSDecompressor.cpp
+++ b/src/LZBSDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool LZBSDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LZBS');
+	return hdr==FourCC("LZBS");
 }
 
 std::unique_ptr<XPKDecompressor> LZBSDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/LZCBDecompressor.cpp
+++ b/src/LZCBDecompressor.cpp
@@ -196,7 +196,7 @@ private:
 
 bool LZCBDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LZCB');
+	return hdr==FourCC("LZCB");
 }
 
 std::unique_ptr<XPKDecompressor> LZCBDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/LZW2Decompressor.cpp
+++ b/src/LZW2Decompressor.cpp
@@ -6,7 +6,7 @@
 
 bool LZW2Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LZW2') || hdr==FourCC('LZW3');
+	return hdr==FourCC("LZW2") || hdr==FourCC("LZW3");
 }
 
 std::unique_ptr<XPKDecompressor> LZW2Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -19,7 +19,7 @@ LZW2Decompressor::LZW2Decompressor(uint32_t hdr,uint32_t recursionLevel,const Bu
 	_packedData(packedData)
 {
 	if (!detectHeaderXPK(hdr)) throw Decompressor::InvalidFormatError();
-	_ver=(hdr==FourCC('LZW2'))?2:3;
+	_ver=(hdr==FourCC("LZW2"))?2:3;
 }
 
 LZW2Decompressor::~LZW2Decompressor()

--- a/src/LZW4Decompressor.cpp
+++ b/src/LZW4Decompressor.cpp
@@ -6,7 +6,7 @@
 
 bool LZW4Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LZW4');
+	return hdr==FourCC("LZW4");
 }
 
 std::unique_ptr<XPKDecompressor> LZW4Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/LZW5Decompressor.cpp
+++ b/src/LZW5Decompressor.cpp
@@ -6,7 +6,7 @@
 
 bool LZW5Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('LZW5');
+	return hdr==FourCC("LZW5");
 }
 
 std::unique_ptr<XPKDecompressor> LZW5Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/LZXDecompressor.cpp
+++ b/src/LZXDecompressor.cpp
@@ -12,7 +12,7 @@
 
 bool LZXDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('ELZX') || hdr==FourCC('SLZX');
+	return hdr==FourCC("ELZX") || hdr==FourCC("SLZX");
 }
 
 std::unique_ptr<XPKDecompressor> LZXDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -25,13 +25,13 @@ LZXDecompressor::LZXDecompressor(uint32_t hdr,uint32_t recursionLevel,const Buff
 	_packedData(packedData)
 {
 	if (!detectHeaderXPK(hdr)) throw Decompressor::InvalidFormatError();
-	if (hdr==FourCC('SLZX')) _isSampled=true;
+	if (hdr==FourCC("SLZX")) _isSampled=true;
 	// There is no good spec on the LZX header content -> lots of unknowns here
 	if (_packedData.size()<41) throw Decompressor::InvalidFormatError();
 	// XPK LZX compression is embedded single file of LZX -> read first file. Ignore rest
 	// this will include flags, which need to be zero anyway
 	uint32_t streamHdr=_packedData.readBE32(0);
-	if (streamHdr!=FourCC('LZX\0')) throw Decompressor::InvalidFormatError();
+	if (streamHdr!=FourCC("LZX\0")) throw Decompressor::InvalidFormatError();
 
 	_rawSize=_packedData.readLE32(12);
 	_packedSize=_packedData.readLE32(16);

--- a/src/MASHDecompressor.cpp
+++ b/src/MASHDecompressor.cpp
@@ -7,7 +7,7 @@
 
 bool MASHDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('MASH');
+	return hdr==FourCC("MASH");
 }
 
 std::unique_ptr<XPKDecompressor> MASHDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/MMCMPDecompressor.cpp
+++ b/src/MMCMPDecompressor.cpp
@@ -8,7 +8,7 @@
 
 bool MMCMPDecompressor::detectHeader(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('ziRC');
+	return hdr==FourCC("ziRC");
 }
 
 std::unique_ptr<Decompressor> MMCMPDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)
@@ -19,7 +19,7 @@ std::unique_ptr<Decompressor> MMCMPDecompressor::create(const Buffer &packedData
 MMCMPDecompressor::MMCMPDecompressor(const Buffer &packedData,bool exactSizeKnown,bool verify) :
 	_packedData(packedData)
 {
-	if (!detectHeader(packedData.readBE32(0)) || packedData.readBE32(4U)!=FourCC('ONia') ||
+	if (!detectHeader(packedData.readBE32(0)) || packedData.readBE32(4U)!=FourCC("ONia") ||
 		packedData.readLE16(8U)!=14U || packedData.size()<24U)
 		throw InvalidFormatError();
 	_blocks=packedData.readLE16(12U);

--- a/src/NONEDecompressor.cpp
+++ b/src/NONEDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool NONEDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('NONE');
+	return hdr==FourCC("NONE");
 }
 
 std::unique_ptr<XPKDecompressor> NONEDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/NUKEDecompressor.cpp
+++ b/src/NUKEDecompressor.cpp
@@ -9,7 +9,7 @@
 
 bool NUKEDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('NUKE') || hdr==FourCC('DUKE');
+	return hdr==FourCC("NUKE") || hdr==FourCC("DUKE");
 }
 
 std::unique_ptr<XPKDecompressor> NUKEDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -22,7 +22,7 @@ NUKEDecompressor::NUKEDecompressor(uint32_t hdr,uint32_t recursionLevel,const Bu
 	_packedData(packedData)
 {
 	if (!detectHeaderXPK(hdr)) throw Decompressor::InvalidFormatError();
-	if (hdr==FourCC('DUKE')) _isDUKE=true;
+	if (hdr==FourCC("DUKE")) _isDUKE=true;
 }
 
 NUKEDecompressor::~NUKEDecompressor()

--- a/src/PPDecompressor.cpp
+++ b/src/PPDecompressor.cpp
@@ -17,12 +17,12 @@ PPDecompressor::PPState::~PPState()
 
 bool PPDecompressor::detectHeader(uint32_t hdr) noexcept
 {
-	return (hdr==FourCC('PP11') || hdr==FourCC('PP20'));
+	return (hdr==FourCC("PP11") || hdr==FourCC("PP20"));
 }
 
 bool PPDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('PWPK');
+	return hdr==FourCC("PWPK");
 }
 
 std::unique_ptr<Decompressor> PPDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)

--- a/src/RAKEDecompressor.cpp
+++ b/src/RAKEDecompressor.cpp
@@ -7,7 +7,7 @@
 
 bool RAKEDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return (hdr==FourCC('FRHT') || hdr==FourCC('RAKE'));
+	return (hdr==FourCC("FRHT") || hdr==FourCC("RAKE"));
 }
 
 std::unique_ptr<XPKDecompressor> RAKEDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -18,7 +18,7 @@ std::unique_ptr<XPKDecompressor> RAKEDecompressor::create(uint32_t hdr,uint32_t 
 RAKEDecompressor::RAKEDecompressor(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify) :
 	XPKDecompressor(recursionLevel),
 	_packedData(packedData),
-	_isRAKE(hdr==FourCC('RAKE'))
+	_isRAKE(hdr==FourCC("RAKE"))
 {
 	if (!detectHeaderXPK(hdr) || packedData.size()<4)
 		throw Decompressor::InvalidFormatError();

--- a/src/RDCNDecompressor.cpp
+++ b/src/RDCNDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool RDCNDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('RDCN');
+	return hdr==FourCC("RDCN");
 }
 
 std::unique_ptr<XPKDecompressor> RDCNDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/RLENDecompressor.cpp
+++ b/src/RLENDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool RLENDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('RLEN');
+	return hdr==FourCC("RLEN");
 }
 
 std::unique_ptr<XPKDecompressor> RLENDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/RNCDecompressor.cpp
+++ b/src/RNCDecompressor.cpp
@@ -10,7 +10,7 @@
 
 bool RNCDecompressor::detectHeader(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('RNC\001') || hdr==FourCC('RNC\002');
+	return hdr==FourCC("RNC\001") || hdr==FourCC("RNC\002");
 }
 
 std::unique_ptr<Decompressor> RNCDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)
@@ -28,7 +28,7 @@ RNCDecompressor::RNCDecompressor(const Buffer &packedData,bool verify) :
 		_rawSize>getMaxRawSize() || _packedSize>getMaxPackedSize()) throw InvalidFormatError();
 
 	bool verified=false;
-	if (hdr==FourCC('RNC\001'))
+	if (hdr==FourCC("RNC\001"))
 	{
 		// now detect between old and new version
 		// since the old and the new version share the same id, there is no foolproof way
@@ -62,7 +62,7 @@ RNCDecompressor::RNCDecompressor(const Buffer &packedData,bool verify) :
 				verified=true;
 			} else _ver=Version::RNC1Old;
 		}
-	} else if (hdr==FourCC('RNC\002')) {
+	} else if (hdr==FourCC("RNC\002")) {
 		_ver=Version::RNC2;
 	} else throw InvalidFormatError();
 

--- a/src/SDHCDecompressor.cpp
+++ b/src/SDHCDecompressor.cpp
@@ -9,7 +9,7 @@
 
 bool SDHCDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('SDHC');
+	return hdr==FourCC("SDHC");
 }
 
 std::unique_ptr<XPKDecompressor> SDHCDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/SHR3Decompressor.cpp
+++ b/src/SHR3Decompressor.cpp
@@ -16,7 +16,7 @@ SHR3Decompressor::SHR3State::~SHR3State()
 
 bool SHR3Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('SHR3');
+	return hdr==FourCC("SHR3");
 }
 
 std::unique_ptr<XPKDecompressor> SHR3Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/SHRIDecompressor.cpp
+++ b/src/SHRIDecompressor.cpp
@@ -16,7 +16,7 @@ SHRIDecompressor::SHRIState::~SHRIState()
 
 bool SHRIDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('SHRI');
+	return hdr==FourCC("SHRI");
 }
 
 std::unique_ptr<XPKDecompressor> SHRIDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/SLZ3Decompressor.cpp
+++ b/src/SLZ3Decompressor.cpp
@@ -6,7 +6,7 @@
 
 bool SLZ3Decompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('SLZ3');
+	return hdr==FourCC("SLZ3");
 }
 
 std::unique_ptr<XPKDecompressor> SLZ3Decompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/SMPLDecompressor.cpp
+++ b/src/SMPLDecompressor.cpp
@@ -7,7 +7,7 @@
 
 bool SMPLDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('SMPL');
+	return hdr==FourCC("SMPL");
 }
 
 std::unique_ptr<XPKDecompressor> SMPLDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/SQSHDecompressor.cpp
+++ b/src/SQSHDecompressor.cpp
@@ -7,7 +7,7 @@
 
 bool SQSHDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('SQSH');
+	return hdr==FourCC("SQSH");
 }
 
 std::unique_ptr<XPKDecompressor> SQSHDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/SXSCDecompressor.cpp
+++ b/src/SXSCDecompressor.cpp
@@ -26,7 +26,7 @@ uint32_t SXSCDecompressor::SXSCReader::readBit()
 
 bool SXSCDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('SASC')||hdr==FourCC('SHSC');
+	return hdr==FourCC("SASC")||hdr==FourCC("SHSC");
 }
 
 std::unique_ptr<XPKDecompressor> SXSCDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)
@@ -37,7 +37,7 @@ std::unique_ptr<XPKDecompressor> SXSCDecompressor::create(uint32_t hdr,uint32_t 
 SXSCDecompressor::SXSCDecompressor(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify) :
 	XPKDecompressor(recursionLevel),
 	_packedData(packedData),
-	_isHSC(hdr==FourCC('SHSC'))
+	_isHSC(hdr==FourCC("SHSC"))
 {
 	if (!detectHeaderXPK(hdr)) throw Decompressor::InvalidFormatError();
 }

--- a/src/StoneCrackerDecompressor.cpp
+++ b/src/StoneCrackerDecompressor.cpp
@@ -40,27 +40,27 @@ bool StoneCrackerDecompressor::detectHeaderAndGeneration(uint32_t hdr,uint32_t &
 	// From 3.00 and onwards we can be certain of the format
 	switch (hdr)
 	{
-		case FourCC('S300'):
+		case FourCC("S300"):
 		generation=3;
 		return true;
 
-		case FourCC('S310'):
+		case FourCC("S310"):
 		generation=4;
 		return true;
 
-		case FourCC('S400'):
+		case FourCC("S400"):
 		generation=5;
 		return true;
 
-		case FourCC('S401'):
+		case FourCC("S401"):
 		generation=6;
 		return true;
 
-		case FourCC('S403'):
+		case FourCC("S403"):
 		generation=7;
 		return true;
 
-		case FourCC('S404'):
+		case FourCC("S404"):
 		generation=8;
 		return true;
 

--- a/src/TDCSDecompressor.cpp
+++ b/src/TDCSDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool TDCSDecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('TDCS');
+	return hdr==FourCC("TDCS");
 }
 
 std::unique_ptr<XPKDecompressor> TDCSDecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/TPWMDecompressor.cpp
+++ b/src/TPWMDecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool TPWMDecompressor::detectHeader(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('TPWM');
+	return hdr==FourCC("TPWM");
 }
 
 std::unique_ptr<Decompressor> TPWMDecompressor::create(const Buffer &packedData,bool exactSizeKnown,bool verify)

--- a/src/XPKMain.cpp
+++ b/src/XPKMain.cpp
@@ -11,7 +11,7 @@
 
 bool XPKMain::detectHeader(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('XPKF');
+	return hdr==FourCC("XPKF");
 }
 
 std::unique_ptr<Decompressor> XPKMain::create(const Buffer &packedData,bool verify,bool exactSizeKnown)

--- a/src/ZENODecompressor.cpp
+++ b/src/ZENODecompressor.cpp
@@ -6,7 +6,7 @@
 
 bool ZENODecompressor::detectHeaderXPK(uint32_t hdr) noexcept
 {
-	return hdr==FourCC('ZENO');
+	return hdr==FourCC("ZENO");
 }
 
 std::unique_ptr<XPKDecompressor> ZENODecompressor::create(uint32_t hdr,uint32_t recursionLevel,const Buffer &packedData,std::unique_ptr<XPKDecompressor::State> &state,bool verify)

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -8,10 +8,9 @@
 #include <string>
 #include <vector>
 
-constexpr uint32_t FourCC(uint32_t cc) noexcept
+constexpr uint32_t FourCC(const char (&cc)[5]) noexcept
 {
-	// return with something else if behavior is not same as in clang/gcc for multibyte literals
-	return cc;
+	return static_cast<uint32_t>((static_cast<uint8_t>(cc[0]) << 24) | (static_cast<uint8_t>(cc[1]) << 16) | (static_cast<uint8_t>(cc[2]) << 8) | static_cast<uint8_t>(cc[3]));
 }
 
 constexpr bool isValidSize(uint64_t &value) noexcept


### PR DESCRIPTION
Multibyte char literals are (as noted in your own comment in the code) implementation-defined. Thanks to `constexpr`, we can express `FourCC` in a cross-platform way that is guaranteed to work the same in each compiler and does not cause any overhead at runtime. Unlike with char literals, it is easy to reason that it will always do the right thing, because it reorders bytes exactly the same way as `Buffer::readBE32` does, which these FourCC values are usually directly compared against.