### PR TITLE
Small fix for main fuzzer bash script

### DIFF
--- a/fuzzing/fuzz-main.sh
+++ b/fuzzing/fuzz-main.sh
@@ -5,6 +5,6 @@ cd "${0%/*}"
 # Create tmpfs for storing temporary fuzzing data
 mkdir $FUZZING_TEMPDIR
 sudo mount -t tmpfs -o size=100M none $FUZZING_TEMPDIR
-cp ancient $FUZZING_TEMPDIR/
+cp ../ancient $FUZZING_TEMPDIR/
 
 $AFL_BIN -f $FUZZING_TEMPDIR/infile01 -x all_formats.dict -t $FUZZING_TIMEOUT $FUZZING_INPUT -o $FUZZING_FINDINGS_DIR -M fuzzer01 $FUZZING_TEMPDIR/ancient $FUZZING_TEMPDIR/infile01


### PR DESCRIPTION
The script tried to copy the binary from the wrong place.

BTW: My fuzzer instances haven't found any new crashes or hangs recently but of course I'll keep them running.