### PR TITLE
Move DecompressorImpl from namespace ancient::internal into namespace ancient::internal::APIv2

### DIFF
--- a/api/ancient/ancient.hpp
+++ b/api/ancient/ancient.hpp
@@ -38,7 +38,10 @@ namespace ancient
 
 namespace internal
 {
+namespace APIv2
+{
 class DecompressorImpl;
+}
 }
 
 inline namespace APIv2
@@ -129,7 +132,7 @@ public:
 
 private:
 
-	std::unique_ptr<internal::DecompressorImpl> m_impl;
+	std::unique_ptr<internal::APIv2::DecompressorImpl> m_impl;
 
 private:
 

--- a/src/API.cpp
+++ b/src/API.cpp
@@ -14,6 +14,9 @@ namespace ancient
 namespace internal
 {
 
+namespace APIv2
+{
+
 class DecompressorImpl
 {
 public:
@@ -33,6 +36,8 @@ public:
 		return;
 	}
 };
+
+}
 
 }
 
@@ -92,13 +97,13 @@ bool Decompressor::detect(const uint8_t *packedData, size_t packedSize) noexcept
 }
 
 Decompressor::Decompressor(const std::vector<uint8_t> &packedData,bool exactSizeKnown,bool verify) :
-	m_impl(std::make_unique<internal::DecompressorImpl>(packedData, exactSizeKnown, verify))
+	m_impl(std::make_unique<internal::APIv2::DecompressorImpl>(packedData, exactSizeKnown, verify))
 {
 	return;
 }
 
 Decompressor::Decompressor(const uint8_t *packedData,size_t packedSize,bool exactSizeKnown,bool verify) :
-	m_impl(std::make_unique<internal::DecompressorImpl>(packedData, packedSize, exactSizeKnown, verify))
+	m_impl(std::make_unique<internal::APIv2::DecompressorImpl>(packedData, packedSize, exactSizeKnown, verify))
 {
 	return;
 }


### PR DESCRIPTION

When we revise the API, this keeps the wrapper of the internal interface also in an isolated namespace to avoid name conflicts.
