### PR TITLE
Fix compilation for Visual Studio 2017

### DIFF
--- a/src/FrequencyTree.hpp
+++ b/src/FrequencyTree.hpp
@@ -192,7 +192,7 @@ private:
 	static constexpr std::array<uint32_t,_levels>	_levelOffsets{makeArray(makeLevelOffsetSequence(std::make_integer_sequence<uint32_t,levels()>{}))};
 	static constexpr std::array<uint32_t,_levels>	_levelSizes{makeArray(makeLevelSizeSequence(std::make_integer_sequence<uint32_t,levels()>{}))};
 
-	std::array<T,size()>				_tree;
+	std::array<T,_size>					_tree;
 };
 
 }


### PR DESCRIPTION
Silly little change... Visual Studio 2017 refuses to assign the result of `size()` to the array size, but using that result via the already-existing static constexpr member, as it is done for the other arrays right next to it, works.