### PR TITLE
Don't rely on implementation-defined behaviour of std::realloc(0)

### DIFF
--- a/fuzzing/fuzz.cpp
+++ b/fuzzing/fuzz.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<Buffer> readFile(const std::string &fileName)
 	}
 	if (!success)
 	{
-		return std::make_shared<StaticBuffer<0>>();
+		return {};
 	}
 	return ret;
 }
@@ -44,6 +44,10 @@ int main(int argc,char **argv)
 #endif
 	
 	auto packed{readFile(argv[1])};
+	if (!packed)
+	{
+		return -1;
+	}
 	std::shared_ptr<Decompressor> decompressor;
 	try
 	{

--- a/src/common/MemoryBuffer.cpp
+++ b/src/common/MemoryBuffer.cpp
@@ -53,8 +53,15 @@ bool MemoryBuffer::isResizable() const noexcept
 	return true;
 }
 
-void MemoryBuffer::resize(size_t newSize) 
+void MemoryBuffer::resize(size_t newSize)
 {
+	if (!newSize)
+	{
+		std::free(_data);
+		_data=nullptr;
+		_size=0;
+		return;
+	}
 	uint8_t *newData=reinterpret_cast<uint8_t*>(std::realloc(_data,newSize));
 	if (!newData)
 	{


### PR DESCRIPTION
Found via fuzzing. `std::realloc(0)` may or may not return a `nullptr`, and if it does return a `nullptr`, it may or may not free the underlying memory. Current `MemoryBuffer` code looks like it either didn't anticipate a `newSize` of 0 being passed, or it was expecting that `std::realloc` would not return a `nullptr` in that case (because it would throw `std::bad_alloc` which is of course wrong). This was effectively leading to a double-free depending on the standard library.

Note: It is debatable if the memory should be freed or not.

As a bonus, this PR also removes non-standard behaviour from fuzz.cpp.