### PR TITLE
Fix dereferencing of end iterator in PPMQ decompressor

### DIFF
--- a/src/PPMQDecompressor.cpp
+++ b/src/PPMQDecompressor.cpp
@@ -267,13 +267,15 @@ void PPMQDecompressor::decompressImpl(Buffer &rawData,const Buffer &previousData
 
 		void scale() noexcept
 		{
-
 			for (auto it=_nodes.begin();it!=_nodes.end();)
 			{
-				auto next=it++;
 				it->freq>>=1U;
-				if (!it->freq) _nodes.erase(it);
-				it=next;
+				if (!it->freq)
+				{
+					it = _nodes.erase(it);
+				} else {
+					it++;
+				}
 			}
 		}
 


### PR DESCRIPTION
Incorrect usage of `std::list::erase` could lead to a crash in the PPMQ decompressor when trying to delete the last item in a list. Issue found with afl++, test case to reproduce: 
[id%253A000151,sig%253A06,src%253A004458,time%253A12244939684,execs%253A3330820005,op%253Ahavoc,rep%253A1.zip](https://github.com/user-attachments/files/16234918/id.253A000151.sig.253A06.src.253A004458.time.253A12244939684.execs.253A3330820005.op.253Ahavoc.rep.253A1.zip)
